### PR TITLE
Avoid calling setState on an unmounted component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-use-css-breakpoints",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "React hook to use breakpoints defined in your CSS.",
   "homepage": "https://github.com/matthewhall/react-use-css-breakpoints#readme",
   "repository": {

--- a/src/use-css-breakpoints.ts
+++ b/src/use-css-breakpoints.ts
@@ -20,7 +20,7 @@ export default function useCssBreakpoints(): string {
 
       const breakpoint: string = parseContentPropFromPseudoElement();
 
-      rAF = window.requestAnimationFrame(() => setState(breakpoint));
+      rAF = window.requestAnimationFrame(() => mounted && setState(breakpoint));
     };
 
     window.addEventListener('resize', onResize, { passive: true });


### PR DESCRIPTION
While using this library I've seen cases of setState being called while the component is still mounted, probably a race condition between RAF and the effect removing the listener. It's not really harmful but it throws a ReactJS console error.

This PR adds a guard to the RAF to avoid that case.