### PR TITLE
Update peer dependency - React versions 17 and 18.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "typescript": "^3.6.4"
       },
       "peerDependencies": {
-        "react": "^16.10.2"
+        "react": "^16.10.2 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "resize"
   ],
   "peerDependencies": {
-    "react": "^16.10.2"
+    "react": "^16.10.2 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.19",


### PR DESCRIPTION
Adding React versions 17 and 18. There shouldn't be any breaking changes with this PR as its just the one React hook. 

Thank you!